### PR TITLE
fix: Remove extra punctuation from header in Label component

### DIFF
--- a/packages/blueprint-react/lib/components/Label/index.tsx
+++ b/packages/blueprint-react/lib/components/Label/index.tsx
@@ -4,7 +4,7 @@ export function Label(props: React.LabelHTMLAttributes<HTMLLabelElement>) {
   const { className, ...restProps } = props;
   return (
     <>
-      <h1>Hello....!!!!!</h1>
+      <h1>Hello....</h1>
       <label
         className={`${styles.label} bg-orange-400 font-medium ${className}`}
         {...restProps}


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install site@0.2.4-canary.41.188e7fe.0
  npm install @locospec/blueprint-react@0.2.4-canary.41.188e7fe.0
  # or 
  yarn add site@0.2.4-canary.41.188e7fe.0
  yarn add @locospec/blueprint-react@0.2.4-canary.41.188e7fe.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
