### PR TITLE
patch: add validation for response data, should be an array

### DIFF
--- a/packages/elements-react/lib/components/Lens/TableHeader.tsx
+++ b/packages/elements-react/lib/components/Lens/TableHeader.tsx
@@ -12,8 +12,12 @@ const TableHeader = ({ headerGroup }: TableHeaderInterface) => {
     <div key={headerGroup.id} className="le-flex ">
       {headerGroup.headers.map((header) => {
         const id = header?.id;
+        const { minSize, maxSize } = header.column.columnDef;
         const addResizeHandler =
-          header.column.columnDef.minSize !== header.column.columnDef.maxSize;
+          minSize !== undefined && maxSize !== undefined
+            ? minSize !== maxSize
+            : true;
+
         const align = (header.column.columnDef.meta as any)?.align;
         const align_class = align ? `le-justify-${align}` : "";
 

--- a/packages/elements-react/lib/components/Lens/hooks/src/useInfiniteFetch.ts
+++ b/packages/elements-react/lib/components/Lens/hooks/src/useInfiniteFetch.ts
@@ -26,6 +26,11 @@ const useInfiniteFetch = ({
       `${dataEndpoint}?cursor=${pageParam}&search=${globalFilter}`
     );
     const responseJson = await response.json();
+
+    if (responseJson?.data && !Array.isArray(responseJson.data)) {
+      throw new Error("Expected data to be an array");
+    }
+
     return responseJson;
   };
 

--- a/packages/elements-react/src/mocks/mirageServer.ts
+++ b/packages/elements-react/src/mocks/mirageServer.ts
@@ -93,7 +93,7 @@ export function makeServer() {
                 accessorKey: "locality",
                 header: "Locality",
                 width: 100,
-                minWidth: 100,
+                // minWidth: 100,
               },
               {
                 accessorKey: "properties",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install site@0.12.1-canary.110.6e9edc5.0
  npm install @locospec/elements-react@0.19.1-canary.110.6e9edc5.0
  # or 
  yarn add site@0.12.1-canary.110.6e9edc5.0
  yarn add @locospec/elements-react@0.19.1-canary.110.6e9edc5.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
